### PR TITLE
Fixes #74 Create proxy url (api/) for json-server localhost url

### DIFF
--- a/src/components/Listings.jsx
+++ b/src/components/Listings.jsx
@@ -11,8 +11,8 @@ const Listings = ({ isHome = false }) => {
 
     useEffect(() => {
         const apiUrl = isHome ? 
-          'http://localhost:8000/jobs?_limit=3' : 
-          'http://localhost:8000/jobs';
+          'api/jobs?_limit=3' : 
+          'api/jobs';
         const fetchJobs = async () => {
             try {
             const res = await fetch(apiUrl);

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,14 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});


### PR DESCRIPTION
In Vite config create a proxy url for the setup back-end server url (http://localhost:888) and rewrite the path to /api which will still go and get data from the old url but use a much cleaner version of the backend url
